### PR TITLE
feat: add new schedule str format

### DIFF
--- a/env_api/scheduler/models/action.py
+++ b/env_api/scheduler/models/action.py
@@ -24,6 +24,7 @@ class Action:
         self.execution_code_str = ""
 
         self.comps_schedule = {}
+        self.str_repr = ""
     
     def set_comps(self, comps):
         self.comps = comps
@@ -68,6 +69,7 @@ class Reversal(AffineAction):
             optim_str += f"\n\t{comp}.loop_reversal({loop_level});"
 
         self.legality_code_str = self.execution_code_str = optim_str
+        self.str_repr = f"R(L{loop_level},comps={comps})"
 
 
 class Interchange(AffineAction):
@@ -83,6 +85,7 @@ class Interchange(AffineAction):
             optim_str += f"\n\t{comp}.interchange({loop_level1}, {loop_level2});"
 
         self.legality_code_str = self.execution_code_str = optim_str
+        self.str_repr = f"I(L{loop_level1},L{loop_level2},comps={comps})"
 
 
 class Skewing(AffineAction):
@@ -102,6 +105,9 @@ class Skewing(AffineAction):
             optim_str += f"\n\t{comp}.skew({loop_level1}, {loop_level2}, {factor1}, {factor2});"
         
         self.legality_code_str = self.execution_code_str = optim_str
+        self.str_repr = (
+            f"S(L{loop_level1},L{loop_level2},{factor1},{factor2},comps={self.comps})"
+        )
 
 class Parallelization(Action):
     def __init__(self, params: list, env_id: int = None, worker_id=""):
@@ -126,6 +132,7 @@ class Parallelization(Action):
         {self.execution_code_str}
         """
         )
+        self.str_repr = f"P(L{loop_level},comps={comps})"
         
 
 
@@ -150,6 +157,7 @@ class Unrolling(Action):
         {self.execution_code_str}
         """
         )
+        self.str_repr = f"U(L{loop_level},{factor},comps={comps})"
 
     def set_params(self, additional_loops):
         loop_level , factor = self.params
@@ -189,6 +197,7 @@ class Tiling(Action):
             optim_str += f"\n\t{comp}.tile({','.join([str(p) for p in self.params])});"
 
         self.execution_code_str = self.legality_code_str = optim_str
+        self.str_repr = f"T{size}({loop_args}{factor_args},comps={comps})"
 
     def apply_on_branches(self, branches, schedule_list: List[Action]):
         tiling_depth = len(self.params)//2

--- a/env_api/scheduler/models/schedule.py
+++ b/env_api/scheduler/models/schedule.py
@@ -112,19 +112,22 @@ class Schedule:
 
     def build_sched_string(self) -> str:
         # Prepare a dictionary of computations name to fill it with each action applied on every comp
-        comps = {}
-        # Map the schedules applied one by one
-        for schedule in self.schedule_list : 
-            # schedule has comps_schedule which includes the comps that was invloved in the optimisation
-            for key in schedule.comps_schedule.keys():
-                # Add the data from that schedule to the global comps dictionnary
-                if(not key in comps or not comps[key]):
-                    comps[key] = ""
-                comps[key] += schedule.comps_schedule[key]
-        # Prepare the string and form it from the comps dictionary
-        schedule_string = ""
-        for key in comps.keys():
-            schedule_string+= "{"+key+"}:"+comps[key]
+        # comps = {}
+        # # Map the schedules applied one by one
+        # for schedule in self.schedule_list : 
+        #     # schedule has comps_schedule which includes the comps that was invloved in the optimisation
+        #     for key in schedule.comps_schedule.keys():
+        #         # Add the data from that schedule to the global comps dictionnary
+        #         if(not key in comps or not comps[key]):
+        #             comps[key] = ""
+        #         comps[key] += schedule.comps_schedule[key]
+        # # Prepare the string and form it from the comps dictionary
+        # schedule_string = ""
+        # for key in comps.keys():
+        #     schedule_string+= "{"+key+"}:"+comps[key]
+        schedule_string = "|".join(optim.str_repr for optim in self.schedule_list)
+        
+
         return schedule_string
     
     def update_actions_mask(self, action : Action,applied : bool = True):


### PR DESCRIPTION
This pull request introduces a new `str_repr` attribute to various action classes in `env_api/scheduler/models/action.py` to provide a string representation of the actions, and refactors the `build_sched_string` method in `env_api/scheduler/models/schedule.py` to utilize this new attribute. These changes aim to simplify the generation of schedule strings and improve code maintainability.

### Enhancements to action classes:
* Added a `str_repr` attribute to the `AffineAction` subclasses (`set_comps` and `set_factors` methods) to store string representations of actions like loop reversal, interchange, skewing, parallelization, unrolling, and tiling. [[1]](diffhunk://#diff-09b9a627497d6b60914e1c5fa33ee7d55e86c4fec8c520bd64a5631b91440540R27) [[2]](diffhunk://#diff-09b9a627497d6b60914e1c5fa33ee7d55e86c4fec8c520bd64a5631b91440540R72) [[3]](diffhunk://#diff-09b9a627497d6b60914e1c5fa33ee7d55e86c4fec8c520bd64a5631b91440540R88) [[4]](diffhunk://#diff-09b9a627497d6b60914e1c5fa33ee7d55e86c4fec8c520bd64a5631b91440540R108-R110) [[5]](diffhunk://#diff-09b9a627497d6b60914e1c5fa33ee7d55e86c4fec8c520bd64a5631b91440540R135) [[6]](diffhunk://#diff-09b9a627497d6b60914e1c5fa33ee7d55e86c4fec8c520bd64a5631b91440540R160) [[7]](diffhunk://#diff-09b9a627497d6b60914e1c5fa33ee7d55e86c4fec8c520bd64a5631b91440540R200)

### Refactoring of schedule string generation:
* Refactored the `build_sched_string` method in `env_api/scheduler/models/schedule.py` to use the `str_repr` attribute from the actions, replacing the previous logic that manually aggregated schedules into a dictionary. This simplifies the code and improves readability.